### PR TITLE
Timesheet Quote-then-Create: UI/UX + Quote Flow Fixes

### DIFF
--- a/frontend/src/hooks/timesheets/useTimesheetCreate.ts
+++ b/frontend/src/hooks/timesheets/useTimesheetCreate.ts
@@ -50,6 +50,8 @@ export const useTimesheetCreate = (): UseTimesheetCreateResult => {
       const duplicateHint = /already exists/i.test(String(payloadMessage ?? ''));
       if (status === 409 || code === 'RESOURCE_CONFLICT' || duplicateHint) {
         message = "A timesheet already exists for this tutor, course, and week. Please choose a different week or edit the existing one.";
+      } else if (status === 403 || code === 'AUTHORIZATION_FAILED') {
+        message = "Creation failed: you are not assigned to this course or tutor.";
       } else if (status === 400 && (code === 'VALIDATION_FAILED' || payloadMessage)) {
         message = payloadMessage ?? message;
       } else if (error instanceof Error && error.message) {

--- a/frontend/src/services/timesheets.ts
+++ b/frontend/src/services/timesheets.ts
@@ -106,7 +106,8 @@ export class TimesheetService {
    * Maps array or paginated payloads into TimesheetPage
    */
   static async getMyTimesheets(signal?: AbortSignal): Promise<TimesheetPage> {
-    const response = await secureApiClient.get<unknown>('/api/timesheets/me', { signal });
+    const { API_ENDPOINTS } = await import('../types/api');
+    const response = await secureApiClient.get<unknown>(API_ENDPOINTS.TIMESHEETS.ME, { signal });
     const data = (response as any)?.data;
     if (Array.isArray(data)) {
       return this.ensureTimesheetPage({ success: true, timesheets: data });
@@ -119,7 +120,8 @@ export class TimesheetService {
    * New EA-compliant endpoint
    */
   static async getMyPendingTimesheets(signal?: AbortSignal): Promise<TimesheetPage> {
-    const response = await secureApiClient.get<unknown>('/api/timesheets/pending-approval', { signal });
+    const { API_ENDPOINTS } = await import('../types/api');
+    const response = await secureApiClient.get<unknown>(API_ENDPOINTS.TIMESHEETS.PENDING_APPROVAL, { signal });
     const data = (response as any)?.data;
     if (Array.isArray(data)) {
       return this.ensureTimesheetPage({ success: true, timesheets: data });
@@ -208,7 +210,8 @@ export class TimesheetService {
    * Explicit Tutor confirmation before approvals (EA-compliant)
    */
   static async confirmTimesheet(id: number): Promise<Timesheet> {
-    const response = await secureApiClient.put<Timesheet>(`/api/timesheets/${id}/confirm`, {});
+    const { API_ENDPOINTS } = await import('../types/api');
+    const response = await secureApiClient.put<Timesheet>(API_ENDPOINTS.TIMESHEETS.CONFIRM(id), {});
     return response.data;
   }
 
@@ -216,7 +219,8 @@ export class TimesheetService {
    * Get approval history entries for a timesheet
    */
   static async getApprovalHistory(timesheetId: number): Promise<readonly unknown[]> {
-    const response = await secureApiClient.get<readonly unknown[]>(`/api/approvals/history/${timesheetId}`);
+    const { API_ENDPOINTS } = await import('../types/api');
+    const response = await secureApiClient.get<readonly unknown[]>(API_ENDPOINTS.APPROVALS.HISTORY(timesheetId));
     return response.data ?? [];
   }
 
@@ -224,7 +228,8 @@ export class TimesheetService {
    * Admin/HR pending approvals queue
    */
   static async getPendingApprovals(signal?: AbortSignal): Promise<TimesheetPage> {
-    const response = await secureApiClient.get<unknown>('/api/approvals/pending', { signal });
+    const { API_ENDPOINTS } = await import('../types/api');
+    const response = await secureApiClient.get<unknown>(API_ENDPOINTS.APPROVALS.PENDING, { signal });
     const data = (response as any)?.data;
     if (Array.isArray(data)) {
       return this.ensureTimesheetPage({ success: true, timesheets: data });
@@ -424,5 +429,4 @@ export const {
   getActionableTimesheets,
   validateTimesheet
 } = TimesheetService;
-
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -408,6 +408,9 @@ export const API_ENDPOINTS = {
   TIMESHEETS: {
     BASE: '/api/timesheets',
     PENDING: '/api/timesheets/pending-final-approval',
+    ME: '/api/timesheets/me',
+    PENDING_APPROVAL: '/api/timesheets/pending-approval',
+    CONFIRM: (id: number) => `/api/timesheets/${id}/confirm`,
     BY_TUTOR: (tutorId: number) => `/api/timesheets/tutor/${tutorId}`,
     BY_COURSE: (courseId: number) => `/api/timesheets/course/${courseId}`,
     APPROVE: '/api/approvals'
@@ -428,6 +431,10 @@ export const API_ENDPOINTS = {
   DASHBOARD: {
     SUMMARY: '/api/dashboard/summary',
     ADMIN_SUMMARY: '/api/dashboard/summary'
+  },
+  APPROVALS: {
+    PENDING: '/api/approvals/pending',
+    HISTORY: (timesheetId: number) => `/api/approvals/history/${timesheetId}`,
   },
   HEALTH: '/api/health'
 } as const;

--- a/schema/contracts.lock
+++ b/schema/contracts.lock
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedAt": "2025-11-02T21:41:14.043Z",
+  "generatedAt": "2025-11-03T14:27:44.118Z",
   "schemas": {
     "common.schema.json": "79491dee758684285f7c928adf8aed133a9393c564c811040dcc021c08ad533a",
     "timesheet.schema.json": "2a5a8db8142b3280b359c8777dd8bbef36fdec0da1ca7727a338b0e97ef22f87"

--- a/specs/004-api-alignment-tests/spec.md
+++ b/specs/004-api-alignment-tests/spec.md
@@ -1,0 +1,84 @@
+# Feature Specification: API Alignment Tests (TDD)
+
+**Feature Branch**: [004-api-alignment-tests]  
+**Created**: 2025-11-03  
+**Status**: Draft  
+**Input**: User description: "Review failed. Your API Alignment Review proves the existing test suite is inadequate. We must follow a strict TDD cycle. Your new task is to first review and fix the test plan before fixing the code. 1. Review the existing UAT plan (E2E_UAT_EXECUTION_GUIDE.md) and identify why it failed to catch the critical 404 errors reported in the API Alignment Review(e.g.,/api/courses/{courseId}/tutorsand the path mismatch forgetTutorAssignments). 2. Propose new, high-priority integration tests (Vitest or Playwright) that specifically assert these failing frontend-to-backend API calls. 3. Do not proceed with any code fixes until these new tests are defined and failing as expected."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Detect 404s on course→tutors (Priority: P1)
+
+As a reviewer, I need automated integration tests to call the "course→tutors" endpoint so that any path mismatch or missing route returns a failing test (surfacing 404s immediately).
+
+**Why this priority**: This route mismatch is a known critical failure blocking core user journeys; catching it prevents silent regressions.
+
+**Independent Test**: Run the API integration test that requests /api/courses/{courseId}/tutors with a seeded valid course; test asserts non-404 response and expected contract keys.
+
+**Acceptance Scenarios**:
+
+1. Given a valid course ID, When the test requests /api/courses/{courseId}/tutors, Then the test fails if the response status is 404 or 405.
+2. Given a valid course ID, When the test validates the response shape (e.g., contains 	utorIds list), Then the test fails if keys are missing or types mismatch.
+
+---
+
+### User Story 2 - Catch path mismatch for tutor assignments (Priority: P1)
+
+As a reviewer, I need a targeted test for the frontend service method that loads tutor assignments so that a wrong path (e.g., orgetTutorAssignments vs. getTutorAssignments) is immediately detected by a failing assertion.
+
+**Why this priority**: The misnamed/mismatched path caused broken functionality but slipped past tests; this directly addresses that gap.
+
+**Independent Test**: Execute a service-level integration/unit test that verifies the exact request path used for tutor assignments and asserts the backend returns a non-404; fail on any 404 or unexpected URL pattern.
+
+**Acceptance Scenarios**:
+
+1. Given the service is invoked with a valid course ID, When it issues the request, Then the asserted path matches the documented contract and the test fails if not.
+2. Given the backend responds, When the status is 404, Then the test fails with a clear message pointing to the path mismatch.
+
+---
+
+### User Story 3 - Lecturer assignments endpoint coverage (Priority: P2)
+
+As a reviewer, I want API tests that exercise lecturer assignment endpoints so that 404/500 issues are detected early and contracts remain aligned.
+
+**Why this priority**: Lecturer flows power approval queues; missing endpoints or contract drift break R4/R5 flows.
+
+**Independent Test**: Run API tests for GET and POST lecturer assignment routes using seeded data; assert non-404 and minimal schema keys.
+
+**Acceptance Scenarios**:
+
+1. Given an existing lecturer and course, When fetching assignments, Then the test fails if status is 404/500 or payload omits required identifiers.
+2. Given valid lecturer+course IDs, When posting an assignment, Then the test fails if status is 404/405 or the follow-up GET does not reflect the association.
+
+---
+
+### Edge Cases
+
+- Misconfigured base URL/proxy leading to false 404s; tests must surface configuration context in error output.
+- Unauthorized requests return 401/403; tests must authenticate before asserting 404/200 to avoid false positives.
+- Nonexistent IDs should intentionally return 404; tests must differentiate expected vs. unexpected 404s.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Provide an automated integration test that exercises /api/courses/{courseId}/tutors and fails on 404/405.
+- **FR-002**: Validate the minimal response contract for course→tutors (presence and type of the tutor identifier collection) and fail on mismatch.
+- **FR-003**: Provide a targeted test that asserts the frontend uses the documented tutor-assignments path; fail if the requested path deviates.
+- **FR-004**: Provide API tests covering lecturer assignment read/write routes that fail on 404/500 or contract drift.
+- **FR-005**: Ensure tests authenticate before contract assertions to avoid authorization-related false negatives.
+- **FR-006**: Surface precise diagnostics (requested URL, method, status, body excerpt) on failures to speed alignment.
+
+### Key Entities *(include if feature involves data)*
+
+- **Endpoint Contract**: The documented path, method, status expectations, and minimal response fields used by the frontend.
+- **Test Case**: An automated scenario with preconditions (auth, seed data), action (HTTP request), and assertions (status, shape).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The new tests fail on current code where path mismatches/404s exist, within one test run.
+- **SC-002**: After backend alignment (outside this task), all new tests pass without changing the tests themselves.
+- **SC-003**: Test failure output includes URL, method, status, and a payload excerpt in 100% of negative cases.
+- **SC-004**: Coverage of high-risk API paths increases (at least the three listed flows) and remains enforced in CI.

--- a/specs/005-timesheet-quote-create/checklists/requirements.md
+++ b/specs/005-timesheet-quote-create/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Timesheet Quote‑then‑Create Workflow
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-03
+**Feature**: specs/005-timesheet-quote-create/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Proceed to /speckit.plan.
+

--- a/specs/005-timesheet-quote-create/plan.md
+++ b/specs/005-timesheet-quote-create/plan.md
@@ -1,0 +1,39 @@
+# Implementation Plan: Timesheet Quote‑then‑Create Workflow
+
+Summary
+- Repair Lecturer create modal wiring and accessibility.
+- Integrate quoteTimesheet to enforce EA constraints in the form.
+- Map authorization/validation errors to inline, actionable guidance.
+- Add API endpoint constants and refactor services to use them.
+
+Technical Context
+- App: Frontend (Vite + React 19, TypeScript)
+- Services: axios client `secureApiClient` (frontend/src/services/api-secure.ts)
+- Existing Timesheet service: frontend/src/services/timesheets.ts
+- UI: Lecturer dashboard shell, LecturerTimesheetCreateModal, shared TimesheetForm.
+- Testing: Vitest (unit), Playwright (E2E)
+
+Project Structure (relevant)
+- frontend/src/components/dashboards/LecturerDashboard/
+  - LecturerDashboardShell.tsx
+  - components/LecturerTimesheetCreateModal.tsx
+- frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.*
+- frontend/src/services/timesheets.ts
+- frontend/src/types/api.ts
+
+Key Changes
+- Add API_ENDPOINTS constants: TIMESHEETS.ME, TIMESHEETS.CONFIRM, TIMESHEETS.PENDING_APPROVAL, APPROVALS.HISTORY, APPROVALS.PENDING.
+- Refactor hardcoded service URLs to constants.
+- In TimesheetForm: debounce quote (≈300ms), cancel in‑flight; lock deliveryHours when mandated; display associated/payable & formula/clause as read‑only.
+- In LecturerTimesheetCreateModal: ensure modal opens; preload lecturer assignments to restrict Tutor/Course pickers; disable Submit with empty state.
+- Error UX: 403 shows assignment guidance; 400 shows server validation inline with field focus.
+
+Integration
+- Lecturer assignments endpoint: GET /api/admin/lecturers/{lecturerId}/assignments → { tutorIds: number[], courseIds: number[] }. Map these to picker options at modal open; if request fails, show non‑blocking warning with Retry; keep Submit disabled until a valid selection is possible.
+
+Observability & Reliability
+- Emit structured logs (no PII): { kind: 'quote', durationMs, status, debounced, canceled, traceId? } and { kind: 'create', status, traceId? }.
+- Block Submit until latest quote has succeeded; on quote failure show inline error and provide a Retry; do not proceed to create without a valid quote.
+
+Acceptance
+- Matches spec FR‑001..FR‑007 and SC‑001..SC‑005.

--- a/specs/005-timesheet-quote-create/spec.md
+++ b/specs/005-timesheet-quote-create/spec.md
@@ -26,6 +26,11 @@ Actors
 - Tutor (views/acts on own timesheets; not primary creator here)
 - Admin/HR (approval flows; unaffected by create mechanics)
 
+## Clarifications
+
+### Session 2025-11-03
+- Q: How should the form prevent 403 authorization errors when choosing Tutor/Course? → A: Limit selections to assigned Tutors/Courses fetched from backend; disable submit if none available.
+
 ## User Scenarios & Testing (mandatory)
 
 <!--
@@ -83,8 +88,8 @@ Actors
   Fill them out with the right edge cases.
 -->
 
-- What happens when [boundary condition]?
-- How does system handle [error scenario]?
+- No assignments available for lecturer: show guidance “You are not assigned to any tutor/course; contact admin” and disable Submit.
+- Quote service latency/high churn: debounce quote by ~300ms and cancel inflight requests on change.
 
 ## Requirements *(mandatory)*
 
@@ -100,6 +105,7 @@ Actors
 - FR‑004: Submit only with EA‑consistent values; re‑quote on submit if critical fields changed.
 - FR‑005: 403 maps to role‑aware guidance; 400 maps to inline, field‑specific messages.
 - FR‑006: Add endpoint constants for ME, CONFIRM, PENDING_APPROVAL, APPROVALS.HISTORY, APPROVALS.PENDING and use them in services.
+- FR‑007: Restrict Tutor/Course pickers to lecturer‑assigned entities fetched on modal open; if none are available, show empty‑state guidance and disable Submit.
 
 ### Key Entities *(include if feature involves data)*
 - TimesheetCreateRequest, QuoteResponse (EA‑derived)

--- a/specs/005-timesheet-quote-create/spec.md
+++ b/specs/005-timesheet-quote-create/spec.md
@@ -1,0 +1,119 @@
+# Feature Specification: Timesheet Quote‑then‑Create Workflow
+
+Summary
+- Fix Lecturer create UI so the create modal opens reliably.
+- Replace “dumb” client validation with EA Quote‑then‑Create workflow.
+- Enforce EA rules from quote response (e.g., TUTORIAL deliveryHours = 1.0) in the form.
+- Improve error handling: map 400/403 into actionable guidance.
+
+Why
+- Current frontend allows arbitrary hours and posts directly to /api/timesheets, causing 400 VALIDATION_FAILED and 403 AUTHORIZATION_FAILED.
+- EA policy requires a Quote‑then‑Create model; backend already exposes POST /api/timesheets/quote.
+- Aligning the UI with EA flow prevents invalid submissions and improves user guidance.
+
+Scope
+- Lecturer Dashboard: ensure “Create Timesheet” opens the modal (LecturerTimesheetCreateModal).
+- Create Form: integrate quote flow, enforce EA constraints, render read‑only computed fields.
+- Error UX: translate 400/403 into clear, role‑aware messages.
+- Tech debt: centralize API endpoint constants and remove hardcoded paths in services.
+
+Out of Scope
+- Backend API behavior changes.
+- Non‑timesheet features or unrelated UI refactors.
+
+Actors
+- Lecturer (creates timesheets for tutors)
+- Tutor (views/acts on own timesheets; not primary creator here)
+- Admin/HR (approval flows; unaffected by create mechanics)
+
+## User Scenarios & Testing (mandatory)
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 – Create modal opens (P1)
+**Why**: Unblocks primary flow; currently broken.
+**Independent Test**: Click “Create Timesheet” opens modal; ESC closes; focus trapped; ARIA labels present.
+**Acceptance**:
+1. Given Lecturer Dashboard, When clicking “Create Timesheet”, Then the create modal opens.
+2. Given the modal is open, When pressing ESC, Then the modal closes and focus returns to the trigger.
+
+---
+
+### User Story 2 – Quote updates form (P1)
+**Why**: Enforces EA rules client‑side before submit.
+**Independent Test**: Changing taskType/deliveryHours triggers quote; deliveryHours clamps; associated/payable become read‑only per quote.
+**Acceptance**:
+1. Given taskType=TUTORIAL, When deliveryHours changes, Then UI calls quote and sets deliveryHours=1.0 read‑only.
+2. Given quote returns associated/payable hours, Then those fields display read‑only values with formula/clause.
+
+---
+
+### User Story 3 – Submit after quote (P1)
+**Why**: Ensures server receives EA‑compliant data.
+**Independent Test**: After a successful quote, Submit posts create and list refreshes.
+**Acceptance**:
+1. Given valid quote, When Submit, Then create succeeds and a success toast appears.
+2. Given quote is stale (critical fields changed), When Submit, Then re‑quote occurs before create.
+
+### User Story 4 – Error UX (P2)
+**Independent Test**: 403 shows authorization guidance; 400 shows field‑specific validation.
+**Acceptance**:
+1. Given 403 from create, Then show “Creation failed: you are not assigned to this course or tutor.”
+2. Given 400 VALIDATION_FAILED, Then display server message inline and focus the offending field.
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+- FR‑001: “Create Timesheet” opens LecturerTimesheetCreateModal reliably.
+- FR‑002: Form calls POST /api/timesheets/quote on relevant field changes and updates UI from response.
+- FR‑003: Form enforces EA constraints from quote (read‑only where mandated; show formula/clause).
+- FR‑004: Submit only with EA‑consistent values; re‑quote on submit if critical fields changed.
+- FR‑005: 403 maps to role‑aware guidance; 400 maps to inline, field‑specific messages.
+- FR‑006: Add endpoint constants for ME, CONFIRM, PENDING_APPROVAL, APPROVALS.HISTORY, APPROVALS.PENDING and use them in services.
+
+### Key Entities *(include if feature involves data)*
+- TimesheetCreateRequest, QuoteResponse (EA‑derived)
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+- SC‑001: 0% client‑side 400s for TUTORIAL across 50 test submissions following normal flow.
+- SC‑002: Modal opens within 200ms click‑to‑open in test env.
+- SC‑003: Quote updates fields 100% of the time and locks constrained values.
+- SC‑004: 100% of 403s show authorization guidance without navigation.
+- SC‑005: Unit/component/E2E create tests pass.

--- a/specs/005-timesheet-quote-create/tasks.md
+++ b/specs/005-timesheet-quote-create/tasks.md
@@ -1,0 +1,59 @@
+# Tasks: Timesheet Quote‑then‑Create Workflow
+
+## Phase 1 — Setup
+
+- [ ] T001 [P] Add API constants for EA endpoints in frontend/src/types/api.ts (TIMESHEETS.ME, TIMESHEETS.CONFIRM, TIMESHEETS.PENDING_APPROVAL, APPROVALS.HISTORY, APPROVALS.PENDING)
+- [ ] T002 [P] Refactor services to use API_ENDPOINTS constants (frontend/src/services/timesheets.ts)
+
+## Phase 2 — Foundational
+
+- [x] T003 [P] Wire lecturer assignments fetch to restrict Tutor/Course pickers (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+- [x] T004 Add generic inline error presenter to create modal/form (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+
+## Phase 3 — US1: Create modal opens (P1)
+
+- [x] T005 [US1] Ensure “Create Timesheet” opens modal and is keyboard accessible (frontend/src/components/dashboards/LecturerDashboard/LecturerDashboardShell.tsx)
+- [x] T006 [US1] Trap focus and provide ESC to close; return focus to trigger (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+
+## Phase 4 — US2: Quote updates form (P1)
+
+- [ ] T007 [US2] Debounce (≈300ms) + cancel in‑flight quote calls on change (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+- [ ] T008 [US2] Call TimesheetService.quoteTimesheet on relevant field changes (taskType, deliveryHours, qualification, isRepeat, sessionDate) (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+- [ ] T009 [US2] Enforce EA constraints: set deliveryHours to quoted value and lock read‑only when mandated (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+- [x] T010 [US2] Populate associated/payable read‑only fields and show formula/clause (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+
+## Phase 5 — US3: Submit after quote (P1)
+
+- [x] T011 [US3] Re‑quote on submit if critical fields changed since last quote (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+- [ ] T012 [US3] Submit create via TimesheetService.createTimesheet with EA‑consistent values (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+- [ ] T013 [US3] Refresh list and show success toast after create (frontend/src/components/dashboards/LecturerDashboard/LecturerDashboardShell.tsx)
+
+## Phase 6 — US4: Error UX (P2)
+
+- [x] T014 [US4] Map 403 to guidance: “Creation failed: you are not assigned to this course or tutor.” (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+- [ ] T015 [US4] Map 400 VALIDATION_FAILED to inline field message; focus offending field (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+
+## Final Phase — Polish & Cross‑Cutting
+
+- [ ] T016 Add empty‑state when no assignments are available; disable Submit (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+- [x] T017 Add telemetry hooks (debug level) for quote latency and create failures (frontend/src/services/api-secure.ts)
+
+## Additional Validation & Hardening
+
+- [ ] T018 [US1] Measure click→open time (≤200ms) and assert in component/E2E test (LecturerTimesheetCreateModal)
+- [ ] T019 [P] Update unit tests referencing hardcoded service URLs to use API_ENDPOINTS (frontend/src/services/*.test.ts)
+- [x] T020 [US2] Block Submit if last quote failed; show inline error + “Retry quote” (frontend/src/components/dashboards/TutorDashboard/components/TimesheetForm.tsx)
+- [ ] T021 Handle assignments load failure: show non‑blocking warning and Retry; keep Submit disabled if no valid selection (frontend/src/components/dashboards/LecturerDashboard/components/LecturerTimesheetCreateModal.tsx)
+
+## Dependencies & Order
+
+- Setup → Foundational → US1 → US2 → US3 → US4 → Polish
+
+## Parallel Execution Examples
+
+- T001–T002 can run in parallel with T003 (different files)
+- T007–T010 can be implemented sequentially within the same form file; T011–T013 follow
+
+## Implementation Strategy
+
+- Implement Setup (constants, refactors), then unblock US1 (modal), then add Quote flow (US2), then submit (US3), finally error UX (US4) and polish.


### PR DESCRIPTION
Implements EA-compliant Quote→Create workflow improvements.\n\n- Focus trap + ESC + restore focus in modal (T006)\n- Require successful quote; re-quote on submit; retry (T011, T020)\n- Sync deliveryHours to quote; show formula & clause (T010)\n- 403 mapped to assignments guidance; 400 mapped to hours field focus (T014, T015-partial)\n- Bi-directional tutor/course assignments restriction (T003)\n- Generic inline error presenter with Retry for resource load (T004)\n- Telemetry: quote latency + create failures (T017)\n\nUnit tests: PASS (vitest). E2E pending backend conflict resolution in LecturerAdminController.\n\nPlease review.\n