### PR TITLE
chore: pause dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,9 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "02:00"
-    open-pull-requests-limit: 10
+    # This repository keeps main as the only long-lived branch.
+    # Pause version-update PR churn; security handling can be managed separately.
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "security"
@@ -17,7 +19,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "02:30"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "security"
@@ -28,7 +30,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "03:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "security"


### PR DESCRIPTION
## Summary
- pause Dependabot version-update PR generation across root npm, frontend npm, and gradle ecosystems
- prepare repository cleanup so `main` remains the only long-lived branch

## Why
- the repository currently has 26 open Dependabot PRs/branches creating maintenance noise
- branch protection blocks direct writes to `main`, so this small PR is the required compliant change to stop the churn at the source

## Validation
- local pre-push parity passed on equivalent change set before remote write
- repo-hygiene: pass
- dependency-security: pass
- backend: pass
- frontend-unit: 590 passed
- e2e: 121 passed
